### PR TITLE
Updated MeCabUniDicNode for UniDic 2.2.0 or later (fix #15)

### DIFF
--- a/src/LibNMeCab/LibNMeCab.xml
+++ b/src/LibNMeCab/LibNMeCab.xml
@@ -935,6 +935,21 @@
             アクセント修飾型を取得
             </summary>
         </member>
+        <member name="P:NMeCab.MeCabUniDicNode.LType">
+            <summary>
+            語彙素類を取得
+            </summary>
+        </member>
+        <member name="P:NMeCab.MeCabUniDicNode.Lid">
+            <summary>
+            語彙表IDを取得
+            </summary>
+        </member>
+        <member name="P:NMeCab.MeCabUniDicNode.Lemma_id">
+            <summary>
+            語彙素IDを取得
+            </summary>
+        </member>
         <member name="T:NMeCab.MeCabUniDicTagger">
             <summary>
             UniDic形式の辞書を使用する場合の形態素解析処理の起点を表します。

--- a/src/LibNMeCab/MeCabUniDicNode.cs
+++ b/src/LibNMeCab/MeCabUniDicNode.cs
@@ -236,6 +236,11 @@ namespace NMeCab
         /// <summary>
         /// 語彙素類を取得
         /// </summary>
+        /// <remarks>
+        /// この項目の「英語」の名前は、
+        /// UniDic 2.2.0 や 2.3.0 の配布物に含まれる dicrc ファイルでは「type」となっているが、
+        /// UniDic の FAQ (https://unidic.ninjal.ac.jp/faq#col_name) には「lType」と記載されている。
+        /// </remarks>
         public string LType
         {
             get { return this.GetFeatureAt(19); }

--- a/src/LibNMeCab/MeCabUniDicNode.cs
+++ b/src/LibNMeCab/MeCabUniDicNode.cs
@@ -166,7 +166,7 @@ namespace NMeCab
         /// </summary>
         public string Kana
         {
-            get { return this.GetFeatureAt(17); }
+            get { return this.GetFeatureAt(20); }
         }
 
         /// <summary>
@@ -174,7 +174,7 @@ namespace NMeCab
         /// </summary>
         public string KanaBase
         {
-            get { return this.GetFeatureAt(18); }
+            get { return this.GetFeatureAt(21); }
         }
 
         /// <summary>
@@ -182,7 +182,7 @@ namespace NMeCab
         /// </summary>
         public string Form
         {
-            get { return this.GetFeatureAt(19); }
+            get { return this.GetFeatureAt(22); }
         }
 
         /// <summary>
@@ -190,7 +190,7 @@ namespace NMeCab
         /// </summary>
         public string FormBase
         {
-            get { return this.GetFeatureAt(20); }
+            get { return this.GetFeatureAt(23); }
         }
 
         /// <summary>
@@ -198,7 +198,7 @@ namespace NMeCab
         /// </summary>
         public string IConType
         {
-            get { return this.GetFeatureAt(21); }
+            get { return this.GetFeatureAt(17); }
         }
 
         /// <summary>
@@ -206,7 +206,7 @@ namespace NMeCab
         /// </summary>
         public string FConType
         {
-            get { return this.GetFeatureAt(22); }
+            get { return this.GetFeatureAt(18); }
         }
 
         /// <summary>
@@ -214,7 +214,7 @@ namespace NMeCab
         /// </summary>
         public string AType
         {
-            get { return this.GetFeatureAt(23); }
+            get { return this.GetFeatureAt(24); }
         }
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace NMeCab
         /// </summary>
         public string AConType
         {
-            get { return this.GetFeatureAt(24); }
+            get { return this.GetFeatureAt(25); }
         }
 
         /// <summary>
@@ -230,7 +230,31 @@ namespace NMeCab
         /// </summary>
         public string AModType
         {
-            get { return this.GetFeatureAt(25); }
+            get { return this.GetFeatureAt(26); }
+        }
+
+        /// <summary>
+        /// 語彙素類を取得
+        /// </summary>
+        public string LType
+        {
+            get { return this.GetFeatureAt(19); }
+        }
+
+        /// <summary>
+        /// 語彙表IDを取得
+        /// </summary>
+        public string Lid
+        {
+            get { return this.GetFeatureAt(27); }
+        }
+
+        /// <summary>
+        /// 語彙素IDを取得
+        /// </summary>
+        public string Lemma_id
+        {
+            get { return this.GetFeatureAt(28); }
         }
     }
 }


### PR DESCRIPTION
修正を作成しました。ご笑覧ください。

- 「語彙素類」は、dicrc では「type」、FAQ では「lType」と記載されています。dicrc（のうち、MeCab の動作に直接関係しない部分）とウェブで公開されている記事とでは、後者の方が誤りが残っている可能性が少ないだろうと考え、対応するプロパティの名前は LType としてあります。
- 素性情報のいくつかの項目は、2.1.2 以前と辞書内での並び順が変わっています。C# ソース上でのプロパティの並び順は従来通りとし、その代わりに、`GetFeaturesAt`の引数が昇順ではなくなるように修正しました。これは主にソース差分を把握しやすくするためです。

なお、この修正により、UniDic 2.1.2 以前とは互換がなくなってしまいます。その妥当性については、ご判断いただきたく。