### PR TITLE
Allows multiple processes to use same dictionary (fix #17)

### DIFF
--- a/src/LibNMeCab/Core/CharProperty.cs
+++ b/src/LibNMeCab/Core/CharProperty.cs
@@ -31,7 +31,7 @@ namespace NMeCab.Core
         {
             string fileName = Path.Combine(dicDir, CharPropertyFile);
 
-            using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read))
+            using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (var reader = new BinaryReader(stream))
             {
                 this.Open(reader, fileName);

--- a/src/LibNMeCab/Core/Connector.cs
+++ b/src/LibNMeCab/Core/Connector.cs
@@ -38,7 +38,16 @@ namespace NMeCab.Core
             string fileName = Path.Combine(dicDir, MatrixFile);
 
 #if MMF_MTX
-            this.mmf = MemoryMappedFile.CreateFromFile(fileName, FileMode.Open, null, 0L, MemoryMappedFileAccess.Read);
+            var sourceFileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
+            try
+            {
+                this.mmf = MemoryMappedFile.CreateFromFile(sourceFileStream, null, 0L, MemoryMappedFileAccess.Read, HandleInheritability.None, false);
+            }
+            catch (Exception)
+            {
+                sourceFileStream.Dispose();
+                throw;
+            }
             this.mmva = this.mmf.CreateViewAccessor(0L, 0L, MemoryMappedFileAccess.Read);
 
             byte* ptr = null;

--- a/src/LibNMeCab/Core/Connector.cs
+++ b/src/LibNMeCab/Core/Connector.cs
@@ -67,7 +67,7 @@ namespace NMeCab.Core
                 this.matrix = (short*)ptr;
             }
 #else
-            using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read))
+            using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (var reader = new BinaryReader(stream))
             {
                 this.LSize = reader.ReadUInt16();

--- a/src/LibNMeCab/Core/MeCabDictionary.cs
+++ b/src/LibNMeCab/Core/MeCabDictionary.cs
@@ -78,7 +78,16 @@ namespace NMeCab.Core
         {
             this.FileName = fileName;
 
-            this.mmf = MemoryMappedFile.CreateFromFile(fileName, FileMode.Open, null, 0L, MemoryMappedFileAccess.Read);
+            var sourceFileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
+            try
+            {
+                this.mmf = MemoryMappedFile.CreateFromFile(sourceFileStream, null, 0L, MemoryMappedFileAccess.Read, HandleInheritability.None, false);
+            }
+            catch (Exception)
+            {
+                sourceFileStream.Dispose();
+                throw;
+            }
             this.mmva = mmf.CreateViewAccessor(0L, 0L, MemoryMappedFileAccess.Read);
 
             byte* ptr = null;

--- a/src/LibNMeCab/Core/MeCabDictionary.cs
+++ b/src/LibNMeCab/Core/MeCabDictionary.cs
@@ -134,7 +134,7 @@ namespace NMeCab.Core
         {
             this.FileName = fileName;
 
-            using (FileStream fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read))
+            using (FileStream fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (BinaryReader reader = new BinaryReader(fileStream))
             {
                 this.Open(reader);


### PR DESCRIPTION
複数起動しようとすると例外が起きる件 (Issue #17) の修正です。

現状の MemoryMappedFile.CreateFromFile の使い方だと、Tagger のインスタンスを Dispose するまで辞書ファイルを排他獲得してしまうことが原因のようでしたので、他のプロセスの Read アクセスを許すように変更しました。(CreateFromFile メソッドにはそういうオーバーロードがないようだったので、ソースがゴタゴタしてしまいました。)

ご査収ください。