### PR TITLE
Marge fix MeCab.DotNet to NMeCab (Issue #32)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# JetBRAINS IDE
+**/.idea/

--- a/src/LibNMeCab/LibNMeCab.csproj
+++ b/src/LibNMeCab/LibNMeCab.csproj
@@ -36,9 +36,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CenterCLR.RelaxVersioner" Version="1.0.10">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="RelaxVersioner" Version="2.3.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/MeCab.DotNet/MeCab.DotNet.csproj
+++ b/src/MeCab.DotNet/MeCab.DotNet.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="RelaxVersioner" Version="2.1.0" PrivateAssets="all" />
+    <PackageReference Include="RelaxVersioner" Version="2.3.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WindowsFormsSample/Properties/AssemblyInfo.cs
+++ b/src/WindowsFormsSample/Properties/AssemblyInfo.cs
@@ -1,36 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
-// アセンブリに関する一般情報は以下の属性セットをとおして制御されます。
-// アセンブリに関連付けられている情報を変更するには、
-// これらの属性値を変更してください。
-[assembly: AssemblyTitle("WindowsFormsSample")]
-[assembly: AssemblyDescription("")]
-//[assembly: AssemblyConfiguration("")]
-//[assembly: AssemblyCompany("")]
-//[assembly: AssemblyProduct("NMeCab")]
-//[assembly: AssemblyCopyright("")]
-//[assembly: AssemblyTrademark("")]
-//[assembly: AssemblyCulture("")]
-
-// ComVisible を false に設定すると、その型はこのアセンブリ内で COM コンポーネントから 
-// 参照不可能になります。COM からこのアセンブリ内の型にアクセスする場合は、
-// その型の ComVisible 属性を true に設定してください。
 [assembly: ComVisible(false)]
-
-// 次の GUID は、このプロジェクトが COM に公開される場合の、typelib の ID です
 [assembly: Guid("e469dd9c-25d9-4062-8db1-41da1449bd70")]
-
-// アセンブリのバージョン情報は、以下の 4 つの値で構成されています:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// すべての値を指定するか、下のように '*' を使ってビルドおよびリビジョン番号を 
-// 既定値にすることができます:
-// [assembly: AssemblyVersion("1.0.*")]
-//[assembly: AssemblyVersion("0.0.0.0")]
-//[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/src/WindowsFormsSample/WindowsFormsSample.csproj
+++ b/src/WindowsFormsSample/WindowsFormsSample.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net45;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net45</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
 
     <DebugType>portable</DebugType>


### PR DESCRIPTION
@komutan  ベースとなるPRを見ました。表面的な部分はOKと思います。少し手直ししたのがこのPRです。

* Linux上でRiderでビルド出来るようにしておきました
* RelaxVersionerの1.xは古いので2.xに移行しました（これでLinux環境でもビルドできます）
* WindowsFormsSampleはMeCabTaggerの廃止があるのでどうしようかと思いましたが、とりあえずビルドできるように修正しました。一通り終わったら、Avalonia辺りに移植しても良いかもと思っています。

----

ターゲットのバージョン（net45やnetstandard2.0、tfmと呼びます）ですが、出来れば絞り込みたいのはヤマヤマなのですが、以下のような経験があります:

* netstandard系列は、.NET Frameworkと.NET Core系列(.NET 5含む) のどちらにも使える。特にnetstandard2.0はnet461とnetcoreapp2.0以降に対応するので、これだけで殆どをカバーできるので、ライブラリはnetstandard2.0で作るのが良さそう
* 一方で:
  * .NET Framework 4.6.1はCLR4.5だけど.NET Framework 4.5ではなく、CLR4.5のベースバージョンと整合しない（CLR4.5で行けるならnet45にしたい、CLR4.0で行けるならnet40にしたい、のような）
  * netstandard2.0のライブラリをnet461以上のプロジェクトで使う場合に、netstandard.dll (2.0)が必要になり、これに引きずられて、本当に必要なのか一見してわからない大量のアセンブリが配置されてしまう
  * MeCabと関係のない、別のライブラリを一緒に使う時（例えばJsonを扱うライブラリなど）、完全に整合するtfmで無い限り、互換性のあるtfmが計算されて選択されますが、この候補が複数ある場合に、望まない選択をしてしまうことがある（しかも現状回避できない）。例えば、NMeCabがnet46/netstandard2.0で、net48プロジェクトで使用すると、netstandard2.0が選択されてしまい、配置されるアセンブリが物凄く多くなってしまいます。NMeCabがnet48のアセンブリを持っていれば、かなり少なくなる筈です（全てnet48で解決されるため）。ライブラリプロジェクトでNMeCabを使用して、更にそのライブラリを使うプロジェクトでも、同じ問題が発生するので、結果はもっと複雑になります（場合によっては、修正できない事があります）
  * 旧形式のMSBuildプロジェクト（長いcsprojになるやつです）で使う場合、packages.configとApp.configに、人間が理解不能な依存関係が大量に入ってしまう

このようなわけで、私のライブラリプロジェクトやNewtonsoft.Jsonのような、幅広い使われ方をするライブラリでは、一見すると使われそうにない多くのtfmに対応させています（特にライブラリパッケージは、大規模プロジェクトで依存関係が複雑になってくると、何でビルド結果がこうなるのかを説明するのが難しいような結果になります）

なので、NMeCabでもいくつかのtfmはサポートしておいたほうが良いと思います。範囲はおまかせします、参考にしてみて下さい:

* 基本的な考え方は、ビルドに適用するtfmと同じものが存在するのが、最小の依存関係になるので望ましい（つまり全部用意するとベストだけど、現実的じゃないので何を除外するかを考える感じです）
* netstandard系列はできるだけ含める
* .NET Framework系列では、節目になるのがnetstandard2.0に対応するnet461で、ここ未満との差が大きいのでよくやるのがnet45,net461,net48 です。クリティカルな場合はnet46を含めます（netstandard1.6に暗に依存した場合に対応させたい場合）
* .NET Core系列は、ターゲットバージョンのSDKがインストールされていないとビルドできないので、netcoreapp2.1,3.1, net5.0を用意しておくとベター（SDKバージョンに対応するアセンブリがない場合は、netstandard系列を使おうとします。.NET Frameworkほどではないですが、依存関係は増えます）
*netstandard1系列とnetcoreapp1系列は、さすがにもう良いかという気はします（netstandard1.6辺りをやっておくと、互換性問題の検証になるかも、ぐらい）。また、netcoreapp2.0とnetcoreapp3.0はディスコンなので、強い心がないなら必要ないかと :) ビルドしたい場合は`CheckEolTargetFramework`を`false`にするといいです。

MeCabは何かのライブラリに使われると言うよりも、最終的なproduct（ASP.NETの実装とか、アプリとか）に使われる方が多いんじゃないかと思うので、上に挙げたライブラリからの利用による依存関係の複雑化についてはそこまで神経質にならなくても良いかも知れません。

----

以下はNewtonsoft.Jsonの例です。12.0.3ではPCLをサポートしていた関係で、かなり多くのftmに対応しています。最新の13.0.1ではPCLを諦めたので、多少減っています。

https://www.nuget.org/packages/Newtonsoft.Json/12.0.3
https://www.nuget.org/packages/Newtonsoft.Json/13.0.1

私のNamingFormatterも、出来るだけ依存性を排除したくて多くのtfmを盛ってあります。netcoreappは入っていませんが...:

https://www.nuget.org/packages/NamingFormatter/2.0.22
