### PR TITLE
問題ない警告の修正です

### DIFF
--- a/src/MeCab.DotNet.Tests/MeCab.DotNet.Tests.csproj
+++ b/src/MeCab.DotNet.Tests/MeCab.DotNet.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netcoreapp2.1;net5.0;net3.5</TargetFrameworks>
     <RootNamespace>MeCab</RootNamespace>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
 
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/src/MeCab.DotNet.Tests/MeCabTaggerTest.cs
+++ b/src/MeCab.DotNet.Tests/MeCabTaggerTest.cs
@@ -17,8 +17,10 @@ namespace MeCab
         [Test]
         public void CreateMulti()
         {
+#pragma warning disable CS0618 // 型またはメンバーが旧型式です
             using var tagger1 = MeCabTagger.Create();
             using var tagger2 = MeCabTagger.Create();
+#pragma warning restore CS0618 // 型またはメンバーが旧型式です
 
             GC.KeepAlive(tagger1);
             GC.KeepAlive(tagger2);
@@ -27,7 +29,9 @@ namespace MeCab
         [Test]
         public void OneBest()
         {
+#pragma warning disable CS0618 // 型またはメンバーが旧型式です
             using var tagger = MeCabTagger.Create();
+#pragma warning restore CS0618 // 型またはメンバーが旧型式です
 
             var nodes = tagger.ParseToNodes("すもももももももものうち").ToArray();
 

--- a/src/WindowsFormsSample/Form1.cs
+++ b/src/WindowsFormsSample/Form1.cs
@@ -11,7 +11,9 @@ namespace WindowsFormsSample
 {
     public partial class Form1 : Form
     {
+#pragma warning disable CS0618 // 型またはメンバーが旧型式です
         MeCabTagger tagger;
+#pragma warning restore CS0618 // 型またはメンバーが旧型式です
 
         private MeCabLatticeLevel LatticeLevel
         {
@@ -89,7 +91,9 @@ namespace WindowsFormsSample
             {
                 Stopwatch sw = Stopwatch.StartNew();
 
+#pragma warning disable CS0618 // 型またはメンバーが旧型式です
                 this.tagger = MeCabTagger.Create();
+#pragma warning restore CS0618 // 型またはメンバーが旧型式です
 
                 sw.Stop();
                 this.toolStripStatusLabel1.Text = string.Format("startup end ({0:0.000}sec)",


### PR DESCRIPTION
@komutan  netcoreapp2.1がdeprecatedになっている件は（最後のMeCab.DotNetパッケージの）リリースをした後で外したいと考えているので、警告を抑制しています。
